### PR TITLE
Create Chapter Headers

### DIFF
--- a/app/components/Chapter.js
+++ b/app/components/Chapter.js
@@ -10,8 +10,8 @@ export default function Chapter({title, text}) {
             "
         >
             <div className="text-center">
-                <h2 className="text-4xl font-bold mb-3">{title}</h2>
-                <p className="text-lg italic text-gray-500">{text}</p>
+                <h2 className="text-4xl font-bold mb-5">{title}</h2>
+                <p className="text-lg italic text-gray-500 px-30">{text}</p>
             </div>
         </section>
     );

--- a/app/page.js
+++ b/app/page.js
@@ -5,13 +5,15 @@ import Section from "./components/Section.js";
 import Closing from "./components/Closing.js";
 import Divider from "./components/Divider.js";
 import Chapter from "./components/Chapter";
-
 export default function Home() {
   return (
       <div className="font-[Patrick_Hand]">
           <Sidebar />
           <main className="relative pl-45 p-3 w-full">
               <Hero />
+              <Divider />
+
+              <About />
               <Divider />
 
               <Chapter
@@ -24,9 +26,6 @@ export default function Home() {
                     asks more questions than it answers, or if its beauty lies in the stillness of reflection. I find that
                     quite elegant. Here are some such pieces that I find myself returning to."
               />
-              <About />
-              <Divider />
-
               <Section id="1" />
               <Divider />
 

--- a/app/page.js
+++ b/app/page.js
@@ -29,6 +29,13 @@ export default function Home() {
               <Section id="1" />
               <Divider />
 
+              <Chapter
+                  title="Activities"
+                  text="Simplicity and depth aren’t mutually exclusive. I prefer things that are steady and undemanding;
+                   they never ask ask for justification, and they don’t require urgency to feel important. They aren’t
+                   rituals in the strict sense. They tend to come around on their own terms—unplanned, unannounced.
+                   Random, maybe, but not unwelcome. These are the activities I trust to keep me untethered in life."
+              />
               <Section id="2" />
               <Divider />
 

--- a/app/page.js
+++ b/app/page.js
@@ -41,7 +41,7 @@ export default function Home() {
 
               <Chapter
                   title="Inspirations"
-                  text="This is asection for what inspires me deeply. It runs a little longer, but that feels fair;
+                  text="This is a section for what inspires me deeply. It runs a little longer, but that feels fair;
                   things that matter tend to unfold slowly."
               />
               <Section id="3" />

--- a/app/page.js
+++ b/app/page.js
@@ -4,6 +4,7 @@ import About from "./components/About";
 import Section from "./components/Section.js";
 import Closing from "./components/Closing.js";
 import Divider from "./components/Divider.js";
+import Chapter from "./components/Chapter";
 
 export default function Home() {
   return (
@@ -13,6 +14,16 @@ export default function Home() {
               <Hero />
               <Divider />
 
+              <Chapter
+                  title="Literature"
+                  text="I’ve always paid attention to the architecture of thought. Writing is an abstraction of the
+                    mind—a deliberate act of selection. And like any structure built under tension, sentences are fragile
+                    by design; a single imbalances echoes through the rest. Even now, I read like a writer and write like
+                    a reader, because I admire literature that reads like thought and moves with a certain intimacy. I’m
+                    drawn to pieces that slow me down and leaves space for silence, for doubt. I don’t mind when a text
+                    asks more questions than it answers, or if its beauty lies in the stillness of reflection. I find that
+                    quite elegant. Here are some such pieces that I find myself returning to."
+              />
               <About />
               <Divider />
 

--- a/app/page.js
+++ b/app/page.js
@@ -39,6 +39,11 @@ export default function Home() {
               <Section id="2" />
               <Divider />
 
+              <Chapter
+                  title="Inspirations"
+                  text="This is asection for what inspires me deeply. It runs a little longer, but that feels fair;
+                  things that matter tend to unfold slowly."
+              />
               <Section id="3" />
               <Divider />
 


### PR DESCRIPTION
## IMPORTANT NOTE
Commits [e348d85](https://github.com/denoire/denoire.github.io/commit/e348d85) (Add reusable Chapter component with title and text props) was originally created on this branch but was merged earlier by accident into ```main```. As a result, it is not visible in this PR's diff but it is part of the feature work. 

### Summary
This PR introduces a reuseable chapter component, and implements the first three chapters with titles and content finalized from #4. The chapters included are:
- Chapter 1: Literature
- Chapter 2: Activities
- Chapter 3: Inspirations